### PR TITLE
docs: add Slack CLI setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,7 @@ slack create my-bolt-js-app --template slack-samples/bolt-js-blank-template
 cd my-bolt-js-app
 ```
 
-#### Creating the Slack app
-
-Use the following command to add your new Slack app to your development workspace. Choose a "local" app environment for upcoming development:
-
-```sh
-slack install
-```
-
-After the Slack app has been created you're all set to start developing!
+After cloning, you're all set to start developing!
 
 </details>
 
@@ -52,21 +44,15 @@ After the Slack app has been created you're all set to start developing!
 2. Choose the workspace you want to install the application to
 3. Copy the contents of [manifest.json](./manifest.json) into the text box that says `*Paste your manifest code here*` (within the JSON tab) and click _Next_
 4. Review the configuration and click _Create_
-5. You'll be redirected to the app settings page for your app. Click _Install App_ in the left hand menu then _Install to Workspace_ and _Allow_ on the screen that follows.
+5. Click _Install to Workspace_ and _Allow_ on the screen that follows. You'll then be redirected to the App Configuration dashboard.
 
 #### Environment Variables
 
-Before you can run the app, you'll need to gather some environment variables.
+Before you can run the app, you'll need to store some environment variables.
 
-1. **Bot token**: Open your [app settings](https://api.slack.com/apps) page, click _OAuth & Permissions_ in the left hand menu, then copy the _Bot User OAuth Token_.
-2. **App token**: Click _Basic Information_ from the left hand menu and follow the steps in the _App-Level Tokens_ section to create an app-level token with the `connections:write` scope.
-
-Once you have these, export both in a shell for following processes:
-
-```sh
-export SLACK_BOT_TOKEN=xoxb-example
-export SLACK_APP_TOKEN=xapp-1-example
-```
+1. Rename `.env.sample` to `.env`
+2. Open your apps configuration page from [this list](https://api.slack.com/apps), click _OAuth & Permissions_ in the left hand menu, then copy the _Bot User OAuth Token_ into your `.env` file under `SLACK_BOT_TOKEN`
+3. Click _Basic Information_ from the left hand menu and follow the steps in the _App-Level Tokens_ section to create an app-level token with the `connections:write` scope. Copy that token into your `.env` as `SLACK_APP_TOKEN`.
 
 #### Initializing the project
 
@@ -99,13 +85,18 @@ slack run
 npm start
 ```
 
-At this point a message should appear in the terminal that notes the Bolt app is running! It doesn't do much else at the moment.
-
 ### Linting
 
-```sh
+```zsh
 # Run lint for code formatting and linting
 npm run lint
+```
+
+### Testing
+
+```zsh
+# Run test for unit tests
+npm test
 ```
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a blank [Bolt for JavaScript](https://docs.slack.dev/tools/bolt-js/) tem
 
 ## Setup
 
-Before getting started, make sure you have a development workspace where you have permissions to install apps. If you don’t have one setup, go ahead and [create one](https://slack.com/create).
+Before getting started, make sure you have a development workspace where you have permissions to install apps. If you don't have one setup, go ahead and [create one](https://slack.com/create).
 
 ### Developer Program
 
@@ -12,7 +12,41 @@ Join the [Slack Developer Program](https://api.slack.com/developer-program) for 
 
 ## Installation
 
-### Create a Slack App
+<details><summary><strong>Using Slack CLI</strong></summary>
+
+Install the latest version of the Slack CLI for your operating system:
+
+- [Slack CLI for macOS & Linux](https://docs.slack.dev/tools/slack-cli/guides/installing-the-slack-cli-for-mac-and-linux/)
+- [Slack CLI for Windows](https://docs.slack.dev/tools/slack-cli/guides/installing-the-slack-cli-for-windows/)
+
+You'll also need to log in if this is your first time using the Slack CLI.
+
+```sh
+slack login
+```
+
+#### Initializing the project
+
+```sh
+slack create my-bolt-js-app --template slack-samples/bolt-js-blank-template
+cd my-bolt-js-app
+```
+
+#### Creating the Slack app
+
+Use the following command to add your new Slack app to your development workspace. Choose a "local" app environment for upcoming development:
+
+```sh
+slack install
+```
+
+After the Slack app has been created you're all set to start developing!
+
+</details>
+
+<details><summary><strong>Using Terminal</strong></summary>
+
+#### Create Your Slack App
 
 1. Open [https://api.slack.com/apps/new](https://api.slack.com/apps/new) and choose "From an app manifest"
 2. Choose the workspace you want to install the application to
@@ -34,25 +68,40 @@ export SLACK_BOT_TOKEN=xoxb-example
 export SLACK_APP_TOKEN=xapp-1-example
 ```
 
-### Setup Your Local Project
+#### Initializing the project
 
 ```sh
-# Clone this project onto your machine
-git clone https://github.com/slack-samples/bolt-js-blank-template.git
+git clone https://github.com/slack-samples/bolt-js-blank-template.git my-bolt-js-app
+cd my-bolt-js-app
+```
 
-# Change into this project directory
-cd bolt-js-blank-template
+#### Install dependencies
 
-# Install dependencies
+```sh
 npm install
+```
 
-# Run Bolt server
+</details>
+
+## Development
+
+### Starting the app
+
+#### Slack CLI
+
+```sh
+slack run
+```
+
+#### Terminal
+
+```sh
 npm start
 ```
 
 At this point a message should appear in the terminal that notes the Bolt app is running! It doesn't do much else at the moment.
 
-#### Linting
+### Linting
 
 ```sh
 # Run lint for code formatting and linting


### PR DESCRIPTION
## Summary

- Adds collapsible "Using Slack CLI" section with install, login, create, and install commands
- Wraps existing manual setup in a collapsible "Using Terminal" section
- Adds a Development section with `slack run` and `npm start` options
- Matches the pattern used by `bolt-js-assistant-template` and `bolt-js-search-template`

## Test plan

- [ ] Verify rendered README displays both collapsible sections correctly
- [ ] Confirm CLI commands reference the correct template repo name