### PR TITLE
chore: add Slack CLI support

### DIFF
--- a/.slack/.gitignore
+++ b/.slack/.gitignore
@@ -1,0 +1,2 @@
+apps.dev.json
+cache/

--- a/.slack/hooks.json
+++ b/.slack/hooks.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "get-hooks": "npx -q --no-install -p @slack/cli-hooks slack-cli-get-hooks"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Join the [Slack Developer Program](https://api.slack.com/developer-program) for 
 
 ## Installation
 
-<details><summary><strong>Using Slack CLI</strong></summary>
+### Using Slack CLI
 
 Install the latest version of the Slack CLI for your operating system:
 
@@ -28,15 +28,18 @@ slack login
 #### Initializing the project
 
 ```sh
-slack create my-bolt-js-app --template slack-samples/bolt-js-blank-template
-cd my-bolt-js-app
+slack create bolt-js-blank --template slack-samples/bolt-js-blank-template
+cd bolt-js-blank
 ```
 
-After cloning, you're all set to start developing!
+#### Running the app
 
-</details>
+```sh
+slack run
+```
 
-<details><summary><strong>Using Terminal</strong></summary>
+<details>
+<summary><h3>Using Terminal</h3></summary>
 
 #### Create Your Slack App
 
@@ -67,23 +70,15 @@ cd my-bolt-js-app
 npm install
 ```
 
-</details>
-
-## Development
-
-### Starting the app
-
-#### Slack CLI
-
-```sh
-slack run
-```
-
-#### Terminal
+#### Starting the app
 
 ```sh
 npm start
 ```
+
+</details>
+
+## Development
 
 ### Linting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@slack/bolt": "^4.7.3"
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.1"
+        "@biomejs/biome": "2.5.1",
+        "@slack/cli-hooks": "^2.0.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -213,6 +214,28 @@
       },
       "peerDependencies": {
         "@types/express": "^5.0.0"
+      }
+    },
+    "node_modules/@slack/cli-hooks": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/cli-hooks/-/cli-hooks-2.0.0.tgz",
+      "integrity": "sha512-VLxGqJZwbrH3S+ovRhqlrcrKWHRDJtn3toraZKAcLaPqca5CgqTa/PmiCvCq3uUowiFw9B7FOB0y3ikQoDppTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.8",
+        "semver": "^7.5.4"
+      },
+      "bin": {
+        "slack-cli-check-update": "src/check-update.js",
+        "slack-cli-doctor": "src/doctor.js",
+        "slack-cli-get-hooks": "src/get-hooks.js",
+        "slack-cli-get-manifest": "src/get-manifest.js",
+        "slack-cli-start": "src/start.js"
+      },
+      "engines": {
+        "node": ">= 20",
+        "npm": ">=9.6.4"
       }
     },
     "node_modules/@slack/logger": {
@@ -1185,6 +1208,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@slack/bolt": "^4.7.3"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.1"
+    "@biomejs/biome": "2.5.1",
+    "@slack/cli-hooks": "^2.0.0"
   }
 }


### PR DESCRIPTION
This standardizes Slack CLI support for this sample so it can be created and run with the Slack CLI (`slack create` / `slack run`), matching the other CLI-enabled Bolt samples.

Adds (only the pieces this repo was missing):
- `.slack/hooks.json` — the CLI `get-hooks` config
- `.slack/.gitignore` — ignores `apps.dev.json` and `cache/` (local CLI state)
- the CLI hooks dependency (`@slack/cli-hooks` for JS/TS, `slack-cli-hooks==0.3.0` for Python)
- a `### Using Slack CLI` README section, with the existing manual flow preserved under `Using Terminal`

Opened as a **draft** for review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)